### PR TITLE
Replace broken link (404 page) with the correct link

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ You can see the docker-scaffold in use in the `site-wxt` repository:
 
 For more information please consult the documentation:
 
-* https://drupalwxt.github.io/en/docs/environment/containers/
+* https://drupalwxt.github.io/docs/environment/containers/
 
 [composer]:                     https://getcomposer.org
 [docker-scaffold]:              https://github.com/drupalwxt/docker-scaffold.git


### PR DESCRIPTION
For some reason the language prefix was removed in the documentation site.  Update the docker-scaffold README.md because otherwise we get a 404 page.